### PR TITLE
Add margin under GR-OSS logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,7 @@
 <h3 align="center">
   <a href="https://opensource.gresearch.com"><img src="https://github.com/G-Research/brand/raw/main/logo/GR-OSS/logo.svg" height="160px" alt="G-Research"></a>
   <br>
+  <br>
   <i>Curious minds. Complex problems. Enduring success.</i>
 </h3>
 <p align="center">


### PR DESCRIPTION
## Issue
<img width="974" height="710" alt="Issue" src="https://github.com/user-attachments/assets/2634daab-8166-43c7-9755-5d993c6dfb01" />

## Preview
https://github.com/naskio/G-Research__.github/blob/profile/fix-layout/profile/README.md
