### PR TITLE
Revert "Add margin under GR-OSS logo"

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,6 @@
 <h3 align="center">
   <a href="https://opensource.gresearch.com"><img src="https://github.com/G-Research/brand/raw/main/logo/GR-OSS/logo.svg" height="160px" alt="G-Research"></a>
   <br>
-  <br>
   <i>Curious minds. Complex problems. Enduring success.</i>
 </h3>
 <p align="center">


### PR DESCRIPTION
Reverts G-Research/.github#8

Page doesn't display logo properly with this change, so the PR will need to be adjusted. 