### PR TITLE
Add zizmor GitHub Actions workflow template

### DIFF
--- a/workflow-templates/zizmor.properties.json
+++ b/workflow-templates/zizmor.properties.json
@@ -1,0 +1,6 @@
+{
+    "name": "zizmor (GitHub Actions static analysis)",
+    "description": "Static analysis of your GitHub Actions workflows with zizmor. Findings are uploaded as SARIF to code scanning.",
+    "iconName": "octicon shield-check",
+    "categories": ["security"]
+}

--- a/workflow-templates/zizmor.yml
+++ b/workflow-templates/zizmor.yml
@@ -1,0 +1,32 @@
+name: zizmor
+
+# Static analysis of GitHub Actions workflows with zizmor
+# (https://docs.zizmor.sh). Results are uploaded as SARIF to
+# Code Scanning; findings do not fail the build.
+
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write # SARIF upload to Code Scanning
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          min-severity: low
+          min-confidence: low


### PR DESCRIPTION
Adds a `workflow-templates/zizmor.yml` workflow template (plus its `.properties.json`) so any repo in the org can add zizmor static analysis from the Actions → New workflow picker.

zizmor (https://docs.zizmor.sh) runs static analysis on GitHub Actions workflows and uploads findings as SARIF to code scanning (non-blocking). The template uses `$default-branch` so it adapts to each repo's default branch on creation — this is the same workflow already running in `g-research/consuldotnet`, generalized into a template.

Tested on a personal `.github` repo: the template appears under the suggested workflows and `$default-branch` expands correctly.