### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates for GitHub Actions used in this repository.

## Details

- **Ecosystem:** `github-actions`
- **Directory:** `/`
- **Schedule:** `weekly`

This keeps the actions referenced in this org-level `.github` repository (e.g. the workflow templates) up to date by having Dependabot open weekly PRs when newer action versions are released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)